### PR TITLE
update smart contract framework

### DIFF
--- a/csharp/AgencyTransaction/AgencyTransaction.csproj
+++ b/csharp/AgencyTransaction/AgencyTransaction.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Neo.SmartContract.Framework, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo.SmartContract.Framework.2.3.0\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
+    <Reference Include="Neo.SmartContract.Framework, Version=2.9.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo.SmartContract.Framework.2.9.3.1\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/AgencyTransaction/packages.config
+++ b/csharp/AgencyTransaction/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Neo.SmartContract.Framework" version="2.3.0" targetFramework="net462" />
+  <package id="Neo.SmartContract.Framework" version="2.9.3.1" targetFramework="net462" />
 </packages>

--- a/csharp/Domain/Domain.csproj
+++ b/csharp/Domain/Domain.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Neo.SmartContract.Framework, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo.SmartContract.Framework.2.3.0\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
+    <Reference Include="Neo.SmartContract.Framework, Version=2.9.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo.SmartContract.Framework.2.9.3.1\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/Domain/packages.config
+++ b/csharp/Domain/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Neo.SmartContract.Framework" version="2.3.0" targetFramework="net462" />
+  <package id="Neo.SmartContract.Framework" version="2.9.3.1" targetFramework="net462" />
 </packages>

--- a/csharp/EventExample/EventExample.csproj
+++ b/csharp/EventExample/EventExample.csproj
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Neo.SmartContract.Framework, Version=2.7.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo.SmartContract.Framework.2.7.3\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Neo.SmartContract.Framework, Version=2.9.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo.SmartContract.Framework.2.9.3.1\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/EventExample/packages.config
+++ b/csharp/EventExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Neo.SmartContract.Framework" version="2.7.3" targetFramework="net40" />
+  <package id="Neo.SmartContract.Framework" version="2.9.3.1" targetFramework="net462" />
 </packages>

--- a/csharp/HelloWorld/HelloWorld.csproj
+++ b/csharp/HelloWorld/HelloWorld.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Neo.SmartContract.Framework, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo.SmartContract.Framework.2.3.0\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
+    <Reference Include="Neo.SmartContract.Framework, Version=2.9.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo.SmartContract.Framework.2.9.3.1\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/HelloWorld/packages.config
+++ b/csharp/HelloWorld/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Neo.SmartContract.Framework" version="2.3.0" targetFramework="net462" />
+  <package id="Neo.SmartContract.Framework" version="2.9.3.1" targetFramework="net462" />
 </packages>

--- a/csharp/ICO_Template/ICO_Template.csproj
+++ b/csharp/ICO_Template/ICO_Template.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Neo.SmartContract.Framework, Version=2.5.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo.SmartContract.Framework.2.5.2\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
+    <Reference Include="Neo.SmartContract.Framework, Version=2.9.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo.SmartContract.Framework.2.9.3.1\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/ICO_Template/packages.config
+++ b/csharp/ICO_Template/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Neo.SmartContract.Framework" version="2.5.2" targetFramework="net461" />
+  <package id="Neo.SmartContract.Framework" version="2.9.3.1" targetFramework="net462" />
 </packages>

--- a/csharp/Lock/Lock.csproj
+++ b/csharp/Lock/Lock.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Neo.SmartContract.Framework, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo.SmartContract.Framework.2.3.0\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
+    <Reference Include="Neo.SmartContract.Framework, Version=2.9.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo.SmartContract.Framework.2.9.3.1\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/Lock/packages.config
+++ b/csharp/Lock/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Neo.SmartContract.Framework" version="2.3.0" targetFramework="net462" />
+  <package id="Neo.SmartContract.Framework" version="2.9.3.1" targetFramework="net462" />
 </packages>

--- a/csharp/MapExample/MapExample.csproj
+++ b/csharp/MapExample/MapExample.csproj
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Neo.SmartContract.Framework, Version=2.7.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo.SmartContract.Framework.2.7.3\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Neo.SmartContract.Framework, Version=2.9.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo.SmartContract.Framework.2.9.3.1\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/MapExample/packages.config
+++ b/csharp/MapExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Neo.SmartContract.Framework" version="2.7.3" targetFramework="net40" />
+  <package id="Neo.SmartContract.Framework" version="2.9.3.1" targetFramework="net462" />
 </packages>

--- a/csharp/NEP5/NEP5.csproj
+++ b/csharp/NEP5/NEP5.csproj
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Neo.SmartContract.Framework, Version=2.7.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>.\Neo.SmartContract.Framework.dll</HintPath>
+    <Reference Include="Neo.SmartContract.Framework, Version=2.9.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo.SmartContract.Framework.2.9.3.1\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/NEP5/packages.config
+++ b/csharp/NEP5/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Neo.SmartContract.Framework" version="2.7.3" targetFramework="net40" />
+  <package id="Neo.SmartContract.Framework" version="2.9.3.1" targetFramework="net462" />
 </packages>

--- a/csharp/StructExample/StructExample.csproj
+++ b/csharp/StructExample/StructExample.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Neo.SmartContract.Framework, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Neo.SmartContract.Framework.2.3.0\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
+    <Reference Include="Neo.SmartContract.Framework, Version=2.9.3.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Neo.SmartContract.Framework.2.9.3.1\lib\net40\Neo.SmartContract.Framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/csharp/StructExample/packages.config
+++ b/csharp/StructExample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Neo.SmartContract.Framework" version="2.3.0" targetFramework="net461" />
+  <package id="Neo.SmartContract.Framework" version="2.9.3.1" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
The smart contract framework is outdated so that the build will be failed if  developers download the project and run it directly. 

Therefore, we should updated all the smart contract framework to the latest version to avoid unnecessary problem.